### PR TITLE
Add support `index_filename` option to `autodoc2`.

### DIFF
--- a/src/autodoc2/config.py
+++ b/src/autodoc2/config.py
@@ -490,7 +490,7 @@ class Config:
         metadata={
             "help": (
                 "The filename of the index file, "
-                "relative to the output directory (in POSIX format)."
+                "relative to `autodocs2_output_dir`(in POSIX format)."
             ),
             "sphinx_type": str,
             "category": "render",

--- a/src/autodoc2/config.py
+++ b/src/autodoc2/config.py
@@ -485,6 +485,18 @@ class Config:
         },
     )
 
+    index_filename: str = dc.field(
+        default="index.rst",
+        metadata={
+            "help": (
+                "The filename of the index file, "
+                "relative to the output directory (in POSIX format)."
+            ),
+            "sphinx_type": str,
+            "category": "render",
+        },
+    )
+
     # TODO regexes
     # module_summary: bool | None = None
     # class_inheritance: bool | None = None

--- a/src/autodoc2/sphinx/extension.py
+++ b/src/autodoc2/sphinx/extension.py
@@ -84,7 +84,9 @@ def run_autodoc(app: Sphinx) -> None:
         content_str = jinja2.Template(config.index_template).render(
             top_level=top_level_modules
         )
-        index_path = Path(app.srcdir) / PurePosixPath(config.output_dir) / "index.rst"
+        index_path = (
+            Path(app.srcdir) / PurePosixPath(config.output_dir) / config.index_filename
+        )
         if not (index_path.exists() and index_path.read_text("utf8") == content_str):
             index_path.parent.mkdir(parents=True, exist_ok=True)
             index_path.write_text(content_str, "utf8")

--- a/src/autodoc2/sphinx/extension.py
+++ b/src/autodoc2/sphinx/extension.py
@@ -85,7 +85,7 @@ def run_autodoc(app: Sphinx) -> None:
             top_level=top_level_modules
         )
         index_path = (
-            Path(app.srcdir) / PurePosixPath(config.output_dir) / config.index_filename
+            Path(app.srcdir) / PurePosixPath(config.output_dir) / PurePosixPath(config.index_filename)
         )
         if not (index_path.exists() and index_path.read_text("utf8") == content_str):
             index_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/autodoc2/sphinx/extension.py
+++ b/src/autodoc2/sphinx/extension.py
@@ -85,7 +85,9 @@ def run_autodoc(app: Sphinx) -> None:
             top_level=top_level_modules
         )
         index_path = (
-            Path(app.srcdir) / PurePosixPath(config.output_dir) / PurePosixPath(config.index_filename)
+            Path(app.srcdir)
+            / PurePosixPath(config.output_dir)
+            / PurePosixPath(config.index_filename)
         )
         if not (index_path.exists() and index_path.read_text("utf8") == content_str):
             index_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Add support `index_filename` option.

Example:

```python
# docs/conf.py

autodoc2_index_filename = "index.md"
```
