### PR TITLE
Renders nested exceptions in classes

### DIFF
--- a/src/autodoc2/render/myst_.py
+++ b/src/autodoc2/render/myst_.py
@@ -259,7 +259,7 @@ class MystRenderer(RendererBase):
                     lines.extend(["```", ""])
 
         for child in self.get_children(
-            item, {"class", "property", "attribute", "method"}
+            item, {"class", "property", "attribute", "method", "exception"}
         ):
             if (
                 child["full_name"].endswith(".__init__")

--- a/src/autodoc2/render/rst_.py
+++ b/src/autodoc2/render/rst_.py
@@ -239,7 +239,7 @@ class RstRenderer(RendererBase):
                     yield ""
 
         for child in self.get_children(
-            item, {"class", "property", "attribute", "method"}
+            item, {"class", "property", "attribute", "method", "exception"}
         ):
             if (
                 child["full_name"].endswith(".__init__")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -258,6 +258,9 @@ def build_package(tmp_path: Path) -> Path:
 
             class Nested:
                 '''This is a nested class.'''
+
+            class NestedEx(Exception):
+                '''This is a nested exception.'''
         """
         ),
         "utf-8",

--- a/tests/test_render/test_basic_myst_.md
+++ b/tests/test_render/test_basic_myst_.md
@@ -129,4 +129,20 @@ package.a
 
 ````
 
+````{py:exception} NestedEx()
+:canonical: package.Class.NestedEx
+
+Bases: {py:obj}`Exception`
+
+```{autodoc2-docstring} package.Class.NestedEx
+```
+
+```{rubric} Initialization
+```
+
+```{autodoc2-docstring} package.Class.NestedEx.__init__
+```
+
+````
+
 `````

--- a/tests/test_render/test_basic_rst_.rst
+++ b/tests/test_render/test_basic_rst_.rst
@@ -101,3 +101,14 @@ API
       :canonical: package.Class.Nested
 
       .. autodoc2-docstring:: package.Class.Nested
+
+   .. py:exception:: NestedEx()
+      :canonical: package.Class.NestedEx
+
+      Bases: :py:obj:`Exception`
+
+      .. autodoc2-docstring:: package.Class.NestedEx
+
+      .. rubric:: Initialization
+
+      .. autodoc2-docstring:: package.Class.NestedEx.__init__


### PR DESCRIPTION
It looks like when enumerating through the nested children of a class, the code also needs to list out exceptions. Adds test.

Should fix what I found in
https://github.com/sphinx-extensions2/sphinx-autodoc2/issues/51