### PR TITLE
`autodoc2_module_summary = False` should still print non-summary API

### DIFF
--- a/src/autodoc2/config.py
+++ b/src/autodoc2/config.py
@@ -365,7 +365,7 @@ class Config:
     module_summary: bool = dc.field(
         default=True,
         metadata={
-            "help": "Whether to include a per-module summary.",
+            "help": "Whether to include tables at the top of each module with the one line summary of each item",
             "sphinx_type": bool,
             "category": "render",
         },

--- a/src/autodoc2/render/myst_.py
+++ b/src/autodoc2/render/myst_.py
@@ -166,9 +166,9 @@ class MystRenderer(RendererBase):
                     )
                     yield ""
 
-            yield from ["### API", ""]
-            for name in visible_children:
-                yield from self.render_item(name)
+        yield from ["### API", ""]
+        for name in visible_children:
+            yield from self.render_item(name)
 
     def render_module(self, item: ItemData) -> t.Iterable[str]:
         """Create the content for a module."""

--- a/src/autodoc2/render/rst_.py
+++ b/src/autodoc2/render/rst_.py
@@ -159,9 +159,9 @@ class RstRenderer(RendererBase):
                     )
                     yield ""
 
-            yield from ["API", "~~~", ""]
-            for name in visible_children:
-                yield from self.render_item(name)
+        yield from ["API", "~~~", ""]
+        for name in visible_children:
+            yield from self.render_item(name)
 
     def render_module(self, item: ItemData) -> t.Iterable[str]:
         """Create the content for a module."""


### PR DESCRIPTION
When `autodoc2_module_summary = False`, each module's page only includes the "Submodules" heading at the top and no other API documentation. I assume this is unintended, and the "summary" being referenced in this config option should only be the tables of each item type at the top of each module.

I think this might have been an off-by-one indentation level error? The code to render the non-summary parts was accidentally indented to the level of the summary check `if`.

If the existing behavior is the intended behavior of this config option, let me know and maybe we can change this to better document what the behavior should be.

I didn't include any tests because I didn't see a pattern for handling combinations of config options, but I did test manually. If you want me to add something that tests this in isolation, let me know.

Thanks!