### PR TITLE
Add API to manually update database before writing files

### DIFF
--- a/src/autodoc2/config.py
+++ b/src/autodoc2/config.py
@@ -485,6 +485,14 @@ class Config:
         },
     )
 
+    db_fixup: t.Callable = dc.field(
+        default = None,
+        metadata={
+            "help": "Callback to fixup database, e.g. manually set 'all' if __all__ is dynamic",
+            "category": "render",
+        },
+    )
+
     # TODO regexes
     # module_summary: bool | None = None
     # class_inheritance: bool | None = None

--- a/src/autodoc2/config.py
+++ b/src/autodoc2/config.py
@@ -486,7 +486,7 @@ class Config:
     )
 
     db_fixup: t.Callable = dc.field(
-        default = None,
+        default=None,
         metadata={
             "help": "Callback to fixup database, e.g. manually set 'all' if __all__ is dynamic",
             "category": "render",

--- a/src/autodoc2/sphinx/extension.py
+++ b/src/autodoc2/sphinx/extension.py
@@ -196,6 +196,10 @@ def run_autodoc_package(app: Sphinx, config: Config, pkg_index: int) -> str | No
     def _warn_render(msg: str, type_: WarningSubtypes) -> None:
         warn_sphinx(msg, type_)
 
+    # invoke user-provided fixups
+    if config.db_fixup:
+        config.db_fixup(autodoc2_db)
+
     # write the files
     output.mkdir(parents=True, exist_ok=True)
     paths = []


### PR DESCRIPTION
Hello,

My Python package doesn't work well with static analysis since I'm setting `__all__` programmatically at runtime. I also have docstrings which are dynamically modified upon import, avoiding a lot of maintenance.

I found this project to be a great fit otherwise, and a nice improvement over AutoAPI. I was able to handle my use case by adding a simple callback which is invoked after the database is built, but before files are generated. In this callback I can fix `all`, update docstrings, etc.

Thanks for considering! I'd be happy to cleanup / add tests if this change is acceptable.