### PR TITLE
Fix? nested id for the link tag (#17)

### DIFF
--- a/src/autodoc2/sphinx/autodoc.py
+++ b/src/autodoc2/sphinx/autodoc.py
@@ -136,7 +136,7 @@ def _set_parents(
     current_class = env.ref_context.get("py:class")
     env.ref_context["py:module"] = mod["full_name"]
     if klass:
-        env.ref_context["py:class"] = klass["full_name"]
+        env.ref_context["py:class"] = None
     try:
         yield
     finally:


### PR DESCRIPTION
The nested id for the tag appears to be solved, but not sure if it affects other part or not.

What I did was setting a breakpoint at https://github.com/sphinx-doc/sphinx/blob/bfce4f54b0fc010b04f0d17ad8b9d47d8c279e1f/sphinx/domains/python/_object.py#L212 and with this
```rst
.. autoclass:: amod.AClass
    :members:
```
in the index.rst. When printing out `classname` it is `None`. (using the name, `amod.AClass`, from the comment in #17)

Since that is how autodoc do it, I set the `py:class` to `None`. With this change, the id appears to be normal and not nested.
