### PR TITLE
Support documenting namespace packages

### DIFF
--- a/src/autodoc2/analysis.py
+++ b/src/autodoc2/analysis.py
@@ -13,7 +13,7 @@ import sys
 import typing as t
 
 from astroid import nodes
-from astroid.builder import AstroidBuilder
+from astroid.builder import AstroidBuilder, build_namespace_package_module
 
 from . import astroid_utils
 
@@ -37,7 +37,10 @@ def analyse_module(
         you can use this to record them.
     """
     # TODO expose record_external_imports everywhere analyse_module is used
-    node = AstroidBuilder().file_build(os.fsdecode(file_path), name)
+    if not file_path.is_dir():
+        node = AstroidBuilder().file_build(os.fsdecode(file_path), name)
+    else:
+        node = build_namespace_package_module(name, file_path.parts)
     yield from walk_node(
         node, State(node.name.split(".", 1)[0], [], exclude_external_imports)
     )

--- a/src/autodoc2/sphinx/extension.py
+++ b/src/autodoc2/sphinx/extension.py
@@ -139,7 +139,8 @@ def run_autodoc_package(app: Sphinx, config: Config, pkg_index: int) -> str | No
     # so we can check if we need to re-analyse them
     hasher = hashlib.sha256()
     for mod_path, _ in sorted(modules):
-        hasher.update(mod_path.read_bytes())
+        if mod_path.is_file():
+            hasher.update(mod_path.read_bytes())
     hash_str = hasher.hexdigest()
 
     if (

--- a/src/autodoc2/utils.py
+++ b/src/autodoc2/utils.py
@@ -107,8 +107,15 @@ def yield_modules(
             name, suffix = os.path.splitext(filename)
             if suffix in extensions:
                 to_yield.setdefault(name, []).append(suffix)
+
         root_path = Path(root)
         rel_mod = root_path.relative_to(folder).parts
+
+        # This is a namespace module.
+        if "__init__.py" not in filenames:
+            yield (root_path, ".".join([*root_mod, *rel_mod]))
+        # Otherwise, the specific `__init__.py` file will be included
+        # below.
         for name, suffixes in to_yield.items():
             suffix = sorted(suffixes, key=_suffix_sort_key)[0]
             yield (root_path / f"{name}{suffix}", ".".join([*root_mod, *rel_mod, name]))


### PR DESCRIPTION
I am hoping to use sphinx-autodoc2 to document [PEP 420](https://peps.python.org/pep-0420/) namespace packages. These are packages which are assembled together via multiple "distributions" which each provide a submodule within the namespace package. The way this is encoded in the package definition on the filesystem is that the directory which defines the namespace package contains submodules, but does not contain an `__init__.py` to define it as a module itself.

sphinx-autodoc2 walks the directory tree of all packages and assumes that there will be a Python file for each module that is then parsed by Astroid. Normal packages have the `__init__.py` but namespace packages do not. This PR changes the module enumeration code to detect when it has been instructed to find all modules in a namespace package and encode that in the module list as the directory path itself represents the module. Then (conveniently) we can use some existing Astroid namespace module builder code to produce the same AST stuff for the rest of the documentation generation pipeline.