### PR TITLE
pre-commit autoupdate 2024-09-28

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,14 +12,14 @@ repos:
           - id: check-yaml
 
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.4.4
+      rev: v0.6.8
       hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
 
     - repo: https://github.com/pre-commit/mirrors-mypy
-      rev: v1.10.0
+      rev: v1.11.2
       hooks:
       - id: mypy
         args: [--config-file=pyproject.toml]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,10 +96,11 @@ nitpick_ignore_regex = [
 
 import typing as t  # noqa: E402
 
-from autodoc2.config import CONFIG_PREFIX, Config, PackageConfig  # noqa: E402
 from docutils import nodes  # noqa: E402
 from sphinx.application import Sphinx  # noqa: E402
 from sphinx.util.docutils import SphinxDirective  # noqa: E402
+
+from autodoc2.config import CONFIG_PREFIX, Config, PackageConfig  # noqa: E402
 
 
 def setup(app: Sphinx) -> None:

--- a/src/autodoc2/render/base.py
+++ b/src/autodoc2/render/base.py
@@ -207,7 +207,7 @@ class RendererBase(abc.ABC):
         """Whether to show the docstring."""
         if self.config.docstrings == "all":
             return True
-        if self.config.docstrings == "direct" and not (
+        if self.config.docstrings == "direct" and not (  # noqa: SIM103
             (item.get("inherited")) or (item.get("doc_inherited"))
         ):
             return True

--- a/src/autodoc2/sphinx/extension.py
+++ b/src/autodoc2/sphinx/extension.py
@@ -42,8 +42,8 @@ def setup(app: Sphinx) -> dict[str, str | bool]:
         sphinx_type = t.Any
         if "sphinx_type" in field.metadata:
             sphinx_type = field.metadata["sphinx_type"]
-            if sphinx_type in (str, int, float, bool, list):
-                sphinx_type = (sphinx_type,)
+            if sphinx_type in (str, int, float, bool, list):  # type: ignore[comparison-overlap]
+                sphinx_type = (sphinx_type,)  # type: ignore[assignment]
         app.add_config_value(
             f"{CONFIG_PREFIX}{name}",
             field.metadata.get("sphinx_default", default),

--- a/tests/test_analyse_module.py
+++ b/tests/test_analyse_module.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import typing as t
 
-from autodoc2.analysis import analyse_module
 import pytest
+
+from autodoc2.analysis import analyse_module
 
 
 def clean_item(item: dict[str, t.Any]) -> dict[str, t.Any]:

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -4,6 +4,10 @@ import io
 from pathlib import Path
 from textwrap import dedent
 
+import pytest
+from sphinx.testing.util import SphinxTestApp
+from sphinx.testing.util import path as sphinx_path
+
 from autodoc2.analysis import analyse_module
 from autodoc2.config import Config
 from autodoc2.db import InMemoryDb
@@ -11,9 +15,6 @@ from autodoc2.render.base import RendererBase
 from autodoc2.render.myst_ import MystRenderer
 from autodoc2.render.rst_ import RstRenderer
 from autodoc2.utils import yield_modules
-import pytest
-from sphinx.testing.util import SphinxTestApp
-from sphinx.testing.util import path as sphinx_path
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I am not quite sure how to resolve the `mypy` feedback.

% `pre-commit autoupdate`
% ` pre-commit run --all-files`
```
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

src/autodoc2/sphinx/extension.py:45: error: Non-overlapping container check (element type: "<typing special form>", container item type: "type[str] | type[int] | type[float] | type[bool] | type[list[Any]]")  [comparison-overlap]
src/autodoc2/sphinx/extension.py:46: error: Incompatible types in assignment (expression has type "tuple[<typing special form>]", variable has type "<typing special form>")  [assignment]
Found 2 errors in 1 file (checked 19 source files)
```