### PR TITLE
Support astroid 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = ["sphinx", "autodoc", "extension", "documentation"]
 urls = {Home = "https://github.com/chrisjsewell/sphinx-autodoc2"}
 requires-python = ">=3.8"
 dependencies = [
-    "astroid>=2.7,<4",
+    "astroid>=2.7,<5",
     "tomli; python_version<'3.11'",
     "typing-extensions"
 ]

--- a/src/autodoc2/analysis.py
+++ b/src/autodoc2/analysis.py
@@ -15,6 +15,7 @@ import typing as t
 
 from astroid import nodes
 from astroid.builder import AstroidBuilder
+from astroid.manager import AstroidManager
 
 from . import astroid_utils
 
@@ -38,7 +39,9 @@ def analyse_module(
         you can use this to record them.
     """
     # TODO expose record_external_imports everywhere analyse_module is used
-    node = AstroidBuilder().file_build(os.fsdecode(file_path), name)
+    node = AstroidBuilder(manager=AstroidManager()).file_build(
+        os.fsdecode(file_path), name
+    )
     yield from walk_node(
         node, State(node.name.split(".", 1)[0], [], exclude_external_imports)
     )


### PR DESCRIPTION
This is useful because astroid 4 added support for Python 3.14.